### PR TITLE
Fixed width of timelist for bug in ie9 

### DIFF
--- a/jquery.simple-dtpicker.css
+++ b/jquery.simple-dtpicker.css
@@ -171,7 +171,7 @@
 
 .datepicker > .datepicker_inner_container > .datepicker_timelist {
 	float: left;
-	width: 4em;
+	width: 4.2em;
 	height: 118px;
 	
 	margin-top: -0.5px;


### PR DESCRIPTION
The bug that a layout collapses in IE9.
#22  Thankyou, John.

![2013-03-11_jquery-simple-datetimepicker_bug_ie9](https://f.cloud.github.com/assets/1780223/244033/ccaa2de6-8a5b-11e2-85b3-96424cf8888b.png)
