### PR TITLE
Improved: working with variable calendar padding

### DIFF
--- a/jquery.simple-dtpicker.js
+++ b/jquery.simple-dtpicker.js
@@ -320,7 +320,8 @@
 		$timelist.children().remove();
 		
 		/* Set height to Timelist (Calendar innerHeight - Calendar padding) */
-		$timelist.css("height", $calendar.innerHeight() - 10 + 'px');
+		$timelist.css("height", $calendar.innerHeight() - parseInt($timelist.css("padding-top").replace(/[^-\d\.]/g, ''))
+		              - parseInt($timelist.css("padding-bottom").replace(/[^-\d\.]/g, '')) + 'px');
 
 		/* Output time cells */
 		for (var hour = 0; hour < 24; hour++) {


### PR DESCRIPTION

![custom-datepicker](https://f.cloud.github.com/assets/1649085/549327/fad76ae8-c2f6-11e2-84a4-99f914c5e5fc.png)
I tried to customize datepicker layout but found one vexatious limitation: `.datepicker_calendar` padding is hardcoded in the `jquery.simple-dtpicker.js` and it is difficult to make smooth layout with another padding (see attached image) without script hacking.
I fixed it using px-trimming solution from [here](http://stackoverflow.com/a/1100653/1051870).