### PR TITLE
Fixing positioning when element is inside of nested relative parent

### DIFF
--- a/jquery.simple-dtpicker.js
+++ b/jquery.simple-dtpicker.js
@@ -894,7 +894,7 @@
 					$picker.parent().css("top", $input.outerHeight() + 2 + "px");
 				}
 				else{
-					$picker.parent().css("top", $input.offset().top + $input.outerHeight() + 2 + "px");
+					$picker.parent().css("top", $input.position().top + $input.outerHeight() + 2 + "px");
 					$picker.parent().css("left", $input.position().left + "px");
 				}
 			});


### PR DESCRIPTION
Example: parent(style=position:relative)>parent>input.  This is the correct way of using jQuery position anyways.
