### PR TITLE
Close a picker when date is selected (dateOnly mode)

### DIFF
--- a/jquery.simple-dtpicker.js
+++ b/jquery.simple-dtpicker.js
@@ -572,13 +572,13 @@
 						"isAnim": false,
 						"isOutputToInputObject": true
 					}, targetDate.getFullYear(), targetDate.getMonth(), targetDate.getDate(), selectedDate.getHours(), selectedDate.getMinutes());
+	                                if ($picker.data("dateOnly") == true && $picker.data("isInline") == false && $picker.data("closeOnSelected")){
+	                                        // Close a picker
+	                                        ActivePickerId = -1;
+	                                        $picker.hide();
+	                                }					
 				});
 				
-                                if ($picker.data("dateOnly") == true && $picker.data("isInline") == false && $picker.data("closeOnSelected")){
-                                        // Close a picker
-                                        ActivePickerId = -1;
-                                        $picker.hide();
-                                }				
 
 				$td.hover(function() {
 					if (! $(this).hasClass('active')) {


### PR DESCRIPTION
Close datepicker when closeOnSelected is true, inLine is false and dateOnly is specified. As it is, the DatePicker won't close if a date is selected and the timepicker is hidden.
