### PR TITLE
add bower support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,8 @@
+{
+  "name": "jquery-simple-datetimepicker",
+  "version": "1.8.0",
+  "main": ["jquery.simple-dtpicker.js","jquery.simple-dtpicker.css"],
+  "dependencies": {
+    "jquery" : ">=1.7.2"
+  }
+}


### PR DESCRIPTION
this file along with the below command will allow people to use this plugin with bower.  Once merged, run the below command to register the plugin in the registry.

bower register jquery-simple-datetimepicker https://github.com/mugifly/jquery-simple-datetimepicker.git
