### PR TITLE
bugfix: fix isPast logic when calendar is in next month display

### DIFF
--- a/jquery.simple-dtpicker.js
+++ b/jquery.simple-dtpicker.js
@@ -601,6 +601,9 @@
 		var isCurrentYear = todayDate.getFullYear() == date.getFullYear();
 		var isCurrentMonth = isCurrentYear && todayDate.getMonth() == date.getMonth();
 		var isCurrentDay = isCurrentMonth && todayDate.getDate() == date.getDate();
+		var isNextYear = (todayDate.getFullYear() + 1 == date.getFullYear());
+		var isNextMonth = (isCurrentYear && todayDate.getMonth() + 1 == date.getMonth()) ||
+			(isNextYear && todayDate.getMonth() === 11 && date.getMonth() === 0);
 		var isPastMonth = false;
 		if (date.getFullYear() < todayDate.getFullYear() || (isCurrentYear && date.getMonth() < todayDate.getMonth())) {
 			isPastMonth = true;
@@ -742,7 +745,9 @@
 		for (var zz = 0; i < cellNum; i++) {
 			var realDay = i + 1 - firstWday;
 
-			var isPast = isPastMonth || (isCurrentMonth && realDay < todayDate.getDate());
+			var isPast = isPastMonth ||
+				(isCurrentMonth && realDay < todayDate.getDate()) ||
+				(isNextMonth && firstWday > i && (beforeMonthLastDay + realDay) < todayDate.getDate());
 
 			if (i % 7 === 0) {
 				$tr = $('<tr>');


### PR DESCRIPTION
When the first line of next month calendar includes dates from this month, previous months dates that are before today should be considered past.