### PR TITLE
FIX: setMinDate/setMaxDate should update input only if not empty

### DIFF
--- a/jquery.simple-dtpicker.js
+++ b/jquery.simple-dtpicker.js
@@ -243,11 +243,18 @@
 			date = new Date(date);
 		}
 		$picker.data("minDate", date);
-		datepicked = new Date(getPickedDate($picker));
-		draw_date($picker, {
-			"isAnim": true,
-			"isOutputToInputObject": true
-		}, ((datepicked > date) ? datepicked : date));
+		if ($input.val()) {
+			datepicked = new Date(getPickedDate($picker));
+			draw_date($picker, {
+				"isAnim": true,
+				"isOutputToInputObject": true
+			}, ((datepicked > date) ? datepicked : date));
+		} else {
+			draw_date($picker, {
+				"isAnim": true,
+				"isOutputToInputObject": false
+			}, date);
+		}
 	};
 
 	/* Set a specific max date to a picker and redraw */
@@ -258,11 +265,18 @@
 			date = new Date(date);
 		}
 		$picker.data("maxDate", date);
-		datepicked = new Date(getPickedDate($picker));
-		draw_date($picker, {
-			"isAnim": true,
-			"isOutputToInputObject": true
-		}, ((datepicked < date) ? datepicked : date));
+		if ($input.val()) {
+			datepicked = new Date(getPickedDate($picker));
+			draw_date($picker, {
+				"isAnim": true,
+				"isOutputToInputObject": true
+			}, ((datepicked < date) ? datepicked : date));
+		} else {
+			draw_date($picker, {
+				"isAnim": true,
+				"isOutputToInputObject": false
+			}, date);
+		}
 	};
 
 	/* Destroy a picker */


### PR DESCRIPTION
Functions setMinDate and setMaxDate now update the input field only if it is not empty; updating when empty could cause problems if input change() event is being used.