### PR TITLE
External locale

### DIFF
--- a/jquery.simple-dtpicker.html
+++ b/jquery.simple-dtpicker.html
@@ -136,6 +136,38 @@
 			<li>"ua" : Ukrainian - Thanks to: goti2</li>
 		</ul>
 
+		<h4>externalLocale</h4>
+		<input type="text" name="externalLocale" value="">
+		<script type="text/javascript">
+			$(function(){
+				$('*[name=externalLocale]').appendDtpicker({
+					"inline": true,
+					"locale": "foo",
+					"externalLocale": {
+						foo: {
+							days: ['foo', 'bar', 'foo', 'bar', 'foo', 'bar', 'foo'],
+							months: ['Foo', 'Bar', 'Foo', 'Bar', 'Foo', 'Bar', 'Foo', 'Bar', 'Foo', 'Bar', 'Foo', 'Bar'],
+							sep: '.',
+							format: 'YYYY.MM.DD hh:mm',
+							prevMonth: 'Foo',
+							nextMonth: 'Bar',
+							today: 'Foobar'
+						}
+					}
+				});
+			});
+		</script>
+		<h5>externalLocale format:</h5>
+		<pre>foo: {
+	days: ['foo', 'bar', 'foo', 'bar', 'foo', 'bar', 'foo'],
+	months: ['Foo', 'Bar', 'Foo', 'Bar', 'Foo', 'Bar', 'Foo', 'Bar', 'Foo', 'Bar', 'Foo', 'Bar'],
+	sep: '.',
+	format: 'YYYY.MM.DD hh:mm',
+	prevMonth: 'Foo',
+	nextMonth: 'Bar',
+	today: 'Foobar'
+}</pre>
+
 		<h4>Change the interval of minute ("minuteInterval": 15)</h4>
 		<input type="text" name="date6" value="">
 		<script type="text/javascript">

--- a/jquery.simple-dtpicker.js
+++ b/jquery.simple-dtpicker.js
@@ -1282,7 +1282,8 @@
 			"onShow": null,
 			"onHide": null,
 			"allowWdays": null,
-			"amPmInTimeList": false
+			"amPmInTimeList": false,
+			"externalLocale": null
 		};
 	};
 
@@ -1308,7 +1309,7 @@
 	/**
 	 * Initialize dtpicker, append to Text input field
 	 * */
-	 $.fn.appendDtpicker = function(config, external_locale) {
+	 $.fn.appendDtpicker = function(config) {
 		var date = new Date();
 		var defaults = getDefaults();
 
@@ -1319,8 +1320,8 @@
 		defaults.inline = false;
 		var options = $.extend(defaults, config);
 
-		if (external_locale !== "undefined") {
-			lang = $.extend(lang, external_locale);
+		if (options.externalLocale != null) {
+			lang = $.extend(lang, options.externalLocale);
 		}
 
 		return this.each(function(i) {

--- a/jquery.simple-dtpicker.js
+++ b/jquery.simple-dtpicker.js
@@ -1308,7 +1308,7 @@
 	/**
 	 * Initialize dtpicker, append to Text input field
 	 * */
-	 $.fn.appendDtpicker = function(config) {
+	 $.fn.appendDtpicker = function(config, external_locale) {
 		var date = new Date();
 		var defaults = getDefaults();
 
@@ -1318,6 +1318,10 @@
 
 		defaults.inline = false;
 		var options = $.extend(defaults, config);
+
+		if (external_locale !== "undefined") {
+			lang = $.extend(lang, external_locale);
+		}
 
 		return this.each(function(i) {
 			/* Checking exist a picker */


### PR DESCRIPTION
If the library is used in an environment that does not support UTF-8, some pre-configured locales do not work as intended. The external_locale object enables the library use without modifications.