### PR TITLE
futureOnly option and current option can be mixed

### DIFF
--- a/jquery.simple-dtpicker.js
+++ b/jquery.simple-dtpicker.js
@@ -175,7 +175,7 @@
 			days: ['Sv', 'P', 'O', 'T', 'C', 'P', 'S'],
 			months: [ "Jan", "Feb", "Mar", "Apr", "Mai", "Jūn", "Jūl", "Avg", "Sep", "Okt", "Nov", "Dec" ],
 			format: 'DD.MM.YYYY hh:mm'
-		}
+		},
 		lt: {
 			days: ['Pr', 'A', 'T', 'K', 'P', 'Š', 'S'],
 			months: [ "Saus.", "Vas.", "Kovas", "Bal.", "Geg.", "Birž.", "Liepa", "Rugp.", "Rugs.", "Spal.", "Lapkr.", "Gruod." ],

--- a/jquery.simple-dtpicker.js
+++ b/jquery.simple-dtpicker.js
@@ -396,6 +396,10 @@
 		}, date.getFullYear(), date.getMonth() - 1, date.getDate(), date.getHours(), date.getMinutes());
 
 		var todayDate = new Date();
+		if ($picker.data("futureOnly") && $picker.data("startDate")) {
+			todayDate = new Date($picker.data("startDate"));
+		}
+
 		var isCurrentYear = todayDate.getFullYear() == date.getFullYear();
 		var isCurrentMonth = isCurrentYear && todayDate.getMonth() == date.getMonth();
 
@@ -697,7 +701,12 @@
 
 		/* Check a specified date */
 		var todayDate = new Date();
+	
+
 		if (isFutureOnly) {
+			if ($picker.data("startDate") {
+				todayDate = new Date($picker.date("startDate"));
+			}
 			if (date.getTime() < todayDate.getTime()) { // Already passed
 				date.setTime(todayDate.getTime());
 			}

--- a/jquery.simple-dtpicker.js
+++ b/jquery.simple-dtpicker.js
@@ -161,6 +161,29 @@
 			prevMonth: 'Előző hónap',
 			nextMonth: 'Következő hónap',
 			today: 'Ma'
+		},
+		fa: {
+			days: ['یکشنبه', 'دوشنبه', 'سه شنبه', 'چهارشنبه', 'پنج شنبه', 'جمعه', 'شنبه'],
+			months: [ "ژانویه", "فبریه", "مارچ", "آپریل", "می", "ژوئن", "جولای", "آگوست", "سپتامبر", "اکتبر", "نوامبر", "دسامبر" ],
+			sep: '-',
+			format: 'YYYY-MM-DD hh:mm',
+			prevMonth: 'ماه قبل',
+			nextMonth: 'ماه بعد',
+			today: 'امروز'
+		},
+		lv: {
+			days: ['Sv', 'P', 'O', 'T', 'C', 'P', 'S'],
+			months: [ "Jan", "Feb", "Mar", "Apr", "Mai", "Jūn", "Jūl", "Avg", "Sep", "Okt", "Nov", "Dec" ],
+			format: 'DD.MM.YYYY hh:mm'
+		}
+		lt: {
+			days: ['Pr', 'A', 'T', 'K', 'P', 'Š', 'S'],
+			months: [ "Saus.", "Vas.", "Kovas", "Bal.", "Geg.", "Birž.", "Liepa", "Rugp.", "Rugs.", "Spal.", "Lapkr.", "Gruod." ],
+			sep: '-',
+			format: 'YYYY-MM-DD hh:mm',
+			prevMonth: 'Praeitas mėnesis',
+			nextMonth: 'Sekantis mėnesis',
+			today: 'Šiandien'
 		}
 	};
 	/* ----- */

--- a/jquery.simple-dtpicker.js
+++ b/jquery.simple-dtpicker.js
@@ -396,8 +396,8 @@
 		}, date.getFullYear(), date.getMonth() - 1, date.getDate(), date.getHours(), date.getMinutes());
 
 		var todayDate = new Date();
-		if ($picker.data("futureOnly") && $picker.data("startDate")) {
-			todayDate = new Date($picker.data("startDate"));
+		if ($picker.data("futureOnly") && $picker.data("current")) {
+			todayDate = new Date($picker.data("current"));
 		}
 
 		var isCurrentYear = todayDate.getFullYear() == date.getFullYear();
@@ -704,8 +704,8 @@
 	
 
 		if (isFutureOnly) {
-			if ($picker.data("startDate") {
-				todayDate = new Date($picker.date("startDate"));
+			if ($picker.data("current")) {
+				todayDate = new Date($picker.data("current"));
 			}
 			if (date.getTime() < todayDate.getTime()) { // Already passed
 				date.setTime(todayDate.getTime());
@@ -1192,6 +1192,7 @@
 		$picker.data('onSelect', opt.onSelect);
 		$picker.data('onInit', opt.onInit);
 		$picker.data('allowWdays', opt.allowWdays);
+		$picker.data('current', opt.current);
 
 		if(opt.amPmInTimeList === true){
 			$picker.data('amPmInTimeList', true);


### PR DESCRIPTION
For now, futureOnly option does not mixed with current option.

I think if there are both futureOnly option and current option, the start time of calendar should be current time. 

Therefore, I changed a bit for enhnacement.

Plus, I add Persian, Latvian, Lithuanian language which in #176 #179 and #180.